### PR TITLE
Fixes invalid glue references with new version of unreal sharp

### DIFF
--- a/Script/IslandGen/IslandGen.csproj
+++ b/Script/IslandGen/IslandGen.csproj
@@ -22,6 +22,6 @@
     </Reference>
 
     <Analyzer Include="..\..\Plugins\UnrealSharp\Binaries\Managed\UnrealSharp.SourceGenerators.dll" />
-    <ProjectReference Include="..\ProjectGlue\ProjectGlue.csproj" />
+    <ProjectReference Include="..\CropoutSampleProject.Glue\CropoutSampleProject.Glue.csproj" />
   </ItemGroup>
 </Project>

--- a/Script/ManagedCropoutSampleProject/ManagedCropoutSampleProject.csproj
+++ b/Script/ManagedCropoutSampleProject/ManagedCropoutSampleProject.csproj
@@ -25,6 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\IslandGen\IslandGen.csproj" />
-    <ProjectReference Include="..\ProjectGlue\ProjectGlue.csproj" />
+    <ProjectReference Include="..\CropoutSampleProject.Glue\CropoutSampleProject.Glue.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I have updated the references for the project to use the new {ProjectName}.Glue instead of ProjectGlue